### PR TITLE
bump aegir from 38.1.8 to 39.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "dep-check": "aegir run dep-check",
     "release": "npm run docs:no-publish && aegir run release && npm run docs"
   },
-  "dependencies": {
-    "aegir": "^38.1.0"
+  "devDependencies": {
+    "aegir": "^39.0.8"
   },
   "workspaces": [
     "packages/*"

--- a/packages/blockstore-core/package.json
+++ b/packages/blockstore-core/package.json
@@ -177,7 +177,7 @@
     "multiformats": "^11.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-blockstore-tests": "^6.0.0"
   },
   "typedoc": {

--- a/packages/blockstore-core/src/memory.ts
+++ b/packages/blockstore-core/src/memory.ts
@@ -1,11 +1,11 @@
-import { BaseBlockstore } from './base.js'
 import { base32 } from 'multiformats/bases/base32'
-import * as raw from 'multiformats/codecs/raw'
 import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
 import * as Digest from 'multiformats/hashes/digest'
+import { BaseBlockstore } from './base.js'
 import * as Errors from './errors.js'
-import type { Await, AwaitIterable } from 'interface-store'
 import type { Pair } from 'interface-blockstore'
+import type { Await, AwaitIterable } from 'interface-store'
 
 export class MemoryBlockstore extends BaseBlockstore {
   private readonly data: Map<string, Uint8Array>

--- a/packages/blockstore-fs/benchmarks/encoding/src/index.ts
+++ b/packages/blockstore-fs/benchmarks/encoding/src/index.ts
@@ -1,11 +1,11 @@
-import { Bench } from 'tinybench'
-import { CID } from 'multiformats/cid'
-import { base8 } from 'multiformats/bases/base8'
 import { base10 } from 'multiformats/bases/base10'
 import { base16upper } from 'multiformats/bases/base16'
+import { base256emoji } from 'multiformats/bases/base256emoji'
 import { base32, base32upper, base32hexupper, base32z } from 'multiformats/bases/base32'
 import { base36, base36upper } from 'multiformats/bases/base36'
-import { base256emoji } from 'multiformats/bases/base256emoji'
+import { base8 } from 'multiformats/bases/base8'
+import { CID } from 'multiformats/cid'
+import { Bench } from 'tinybench'
 
 const RESULT_PRECISION = 2
 

--- a/packages/blockstore-fs/package.json
+++ b/packages/blockstore-fs/package.json
@@ -173,7 +173,7 @@
     "multiformats": "^11.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-blockstore-tests": "^6.0.0"
   },
   "typedoc": {

--- a/packages/blockstore-fs/src/index.ts
+++ b/packages/blockstore-fs/src/index.ts
@@ -1,18 +1,18 @@
 import fs from 'node:fs/promises'
-import glob from 'it-glob'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import {
   Errors
 } from 'blockstore-core'
-import map from 'it-map'
-import parallelBatch from 'it-parallel-batch'
 // @ts-expect-error no types
 import fwa from 'fast-write-atomic'
-import type { CID } from 'multiformats/cid'
+import glob from 'it-glob'
+import map from 'it-map'
+import parallelBatch from 'it-parallel-batch'
+import { NextToLast, type ShardingStrategy } from './sharding.js'
 import type { Blockstore, Pair } from 'interface-blockstore'
 import type { AwaitIterable } from 'interface-store'
-import { NextToLast, ShardingStrategy } from './sharding.js'
+import type { CID } from 'multiformats/cid'
 
 const writeAtomic = promisify(fwa)
 

--- a/packages/blockstore-fs/src/sharding.ts
+++ b/packages/blockstore-fs/src/sharding.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { CID } from 'multiformats/cid'
 import { base32upper } from 'multiformats/bases/base32'
+import { CID } from 'multiformats/cid'
 import type { MultibaseCodec } from 'multiformats/bases/interface'
 
 export interface ShardingStrategy {

--- a/packages/blockstore-fs/test/index.spec.ts
+++ b/packages/blockstore-fs/test/index.spec.ts
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
-import { expect } from 'aegir/chai'
-import path from 'node:path'
-import os from 'node:os'
 import fs from 'node:fs/promises'
-import { CID } from 'multiformats/cid'
+import os from 'node:os'
+import path from 'node:path'
+import { expect } from 'aegir/chai'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
+import { base256emoji } from 'multiformats/bases/base256emoji'
+import { CID } from 'multiformats/cid'
 import { FsBlockstore } from '../src/index.js'
 import { FlatDirectory, NextToLast } from '../src/sharding.js'
-import { base256emoji } from 'multiformats/bases/base256emoji'
 
 const utf8Encoder = new TextEncoder()
 

--- a/packages/blockstore-fs/test/sharding.spec.ts
+++ b/packages/blockstore-fs/test/sharding.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
+import { base32upper } from 'multiformats/bases/base32'
 import { CID } from 'multiformats/cid'
 import { FlatDirectory, NextToLast } from '../src/sharding.js'
-import { base32upper } from 'multiformats/bases/base32'
 
 describe('flat', () => {
   it('should encode', () => {

--- a/packages/blockstore-idb/package.json
+++ b/packages/blockstore-idb/package.json
@@ -149,7 +149,7 @@
     "multiformats": "^11.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-blockstore-tests": "^6.0.0"
   },
   "typedoc": {

--- a/packages/blockstore-idb/src/index.ts
+++ b/packages/blockstore-idb/src/index.ts
@@ -1,15 +1,15 @@
-import { openDB, IDBPDatabase, deleteDB } from 'idb'
 import {
   BaseBlockstore,
   Errors
 } from 'blockstore-core'
-import { CID } from 'multiformats/cid'
-import type { MultibaseCodec } from 'multiformats/bases/interface'
+import { openDB, type IDBPDatabase, deleteDB } from 'idb'
 import { base32upper } from 'multiformats/bases/base32'
+import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import * as Digest from 'multiformats/hashes/digest'
 import type { Pair } from 'interface-blockstore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
+import type { MultibaseCodec } from 'multiformats/bases/interface'
 
 export interface IDBDatastoreInit {
   /**

--- a/packages/blockstore-idb/test/index.spec.ts
+++ b/packages/blockstore-idb/test/index.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { IDBBlockstore } from '../src/index.js'
-import { CID } from 'multiformats/cid'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
+import { CID } from 'multiformats/cid'
+import { IDBBlockstore } from '../src/index.js'
 
 describe('IndexedDB Blockstore', function () {
   describe('interface-blockstore (idb)', () => {

--- a/packages/blockstore-level/package.json
+++ b/packages/blockstore-level/package.json
@@ -152,7 +152,7 @@
     "multiformats": "^11.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-blockstore-tests": "^6.0.0",
     "ipfs-utils": "^9.0.4",
     "memory-level": "^1.0.0"

--- a/packages/blockstore-level/src/index.ts
+++ b/packages/blockstore-level/src/index.ts
@@ -1,13 +1,13 @@
-import type { Pair } from 'interface-blockstore'
 import { BaseBlockstore, Errors } from 'blockstore-core'
 import { Level } from 'level'
-import { CID } from 'multiformats/cid'
-import type { DatabaseOptions, OpenOptions, IteratorOptions } from 'level'
-import type { MultibaseCodec } from 'multiformats/bases/interface'
 import { base32upper } from 'multiformats/bases/base32'
+import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import * as Digest from 'multiformats/hashes/digest'
+import type { Pair } from 'interface-blockstore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
+import type { DatabaseOptions, OpenOptions, IteratorOptions } from 'level'
+import type { MultibaseCodec } from 'multiformats/bases/interface'
 
 export interface LevelBlockstoreInit extends DatabaseOptions<string, Uint8Array>, OpenOptions {
   /**

--- a/packages/blockstore-level/test/fixtures/test-level-iterator-destroy.ts
+++ b/packages/blockstore-level/test/fixtures/test-level-iterator-destroy.ts
@@ -1,6 +1,6 @@
-import { LevelBlockstore } from '../../src/index.js'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
 import { CID } from 'multiformats/cid'
+import { LevelBlockstore } from '../../src/index.js'
 
 async function testLevelIteratorDestroy (): Promise<void> {
   const store = new LevelBlockstore(tempdir())

--- a/packages/blockstore-level/test/index.spec.ts
+++ b/packages/blockstore-level/test/index.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { MemoryLevel } from 'memory-level'
-import { Level } from 'level'
-import { LevelBlockstore } from '../src/index.js'
-import tempdir from 'ipfs-utils/src/temp-dir.js'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
+import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { Level } from 'level'
+import { MemoryLevel } from 'memory-level'
+import { LevelBlockstore } from '../src/index.js'
 
 describe('LevelBlockstore', () => {
   describe('initialization', () => {

--- a/packages/blockstore-level/test/node.ts
+++ b/packages/blockstore-level/test/node.ts
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
-import { expect } from 'aegir/chai'
-import path from 'path'
 import childProcess from 'child_process'
+import path from 'path'
+import { expect } from 'aegir/chai'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
-import { LevelBlockstore } from '../src/index.js'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { LevelBlockstore } from '../src/index.js'
 
 describe('LevelDatastore', () => {
   describe('interface-blockstore (leveldown)', () => {

--- a/packages/blockstore-s3/package.json
+++ b/packages/blockstore-s3/package.json
@@ -151,6 +151,7 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
+    "@types/sinon": "^10.0.15",
     "aegir": "^38.1.7",
     "interface-blockstore-tests": "^6.0.0",
     "p-defer": "^4.0.0",

--- a/packages/blockstore-s3/package.json
+++ b/packages/blockstore-s3/package.json
@@ -152,7 +152,7 @@
   },
   "devDependencies": {
     "@types/sinon": "^10.0.15",
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-blockstore-tests": "^6.0.0",
     "p-defer": "^4.0.0",
     "sinon": "^15.0.2"

--- a/packages/blockstore-s3/src/index.ts
+++ b/packages/blockstore-s3/src/index.ts
@@ -1,10 +1,3 @@
-import type { Pair } from 'interface-blockstore'
-import { BaseBlockstore } from 'blockstore-core/base'
-import * as Errors from 'blockstore-core/errors'
-import { fromString as unint8arrayFromString } from 'uint8arrays'
-import toBuffer from 'it-to-buffer'
-import type { S3 } from '@aws-sdk/client-s3'
-import type { AbortOptions } from 'interface-store'
 import {
   PutObjectCommand,
   CreateBucketCommand,
@@ -13,8 +6,15 @@ import {
   DeleteObjectCommand,
   ListObjectsV2Command
 } from '@aws-sdk/client-s3'
+import { BaseBlockstore } from 'blockstore-core/base'
+import * as Errors from 'blockstore-core/errors'
+import toBuffer from 'it-to-buffer'
+import { fromString as unint8arrayFromString } from 'uint8arrays'
+import { NextToLast, type ShardingStrategy } from './sharding.js'
+import type { S3 } from '@aws-sdk/client-s3'
+import type { Pair } from 'interface-blockstore'
+import type { AbortOptions } from 'interface-store'
 import type { CID } from 'multiformats/cid'
-import { NextToLast, ShardingStrategy } from './sharding.js'
 
 export interface S3BlockstoreInit {
   /**

--- a/packages/blockstore-s3/src/sharding.ts
+++ b/packages/blockstore-s3/src/sharding.ts
@@ -1,5 +1,5 @@
-import { CID } from 'multiformats/cid'
 import { base32upper } from 'multiformats/bases/base32'
+import { CID } from 'multiformats/cid'
 import type { MultibaseCodec } from 'multiformats/bases/interface'
 
 export interface ShardingStrategy {

--- a/packages/blockstore-s3/test/index.spec.ts
+++ b/packages/blockstore-s3/test/index.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-env mocha */
 
+import { type CreateBucketCommand, type HeadObjectCommand, S3 } from '@aws-sdk/client-s3'
 import { expect } from 'aegir/chai'
-import sinon from 'sinon'
-import { CreateBucketCommand, HeadObjectCommand, S3 } from '@aws-sdk/client-s3'
-import defer from 'p-defer'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
 import { CID } from 'multiformats/cid'
-
-import { s3Resolve, s3Reject, S3Error, s3Mock } from './utils/s3-mock.js'
+import defer from 'p-defer'
+import sinon from 'sinon'
 import { S3Blockstore } from '../src/index.js'
+import { s3Resolve, s3Reject, S3Error, s3Mock } from './utils/s3-mock.js'
 
 const cid = CID.parse('QmeimKZyjcBnuXmAD9zMnSjM9JodTbgGT3gutofkTqz9rE')
 

--- a/packages/blockstore-s3/test/utils/s3-mock.ts
+++ b/packages/blockstore-s3/test/utils/s3-mock.ts
@@ -30,9 +30,9 @@ export const s3Reject = <T> (err: T): any => {
  */
 export function s3Mock (s3: S3): S3 {
   const mocks: any = {}
-  const storage: Map<string, any> = new Map()
+  const storage = new Map<string, any>()
 
-  mocks.send = sinon.replace(s3, 'send', (command) => {
+  mocks.send = sinon.replace(s3, 'send', (command: Parameters<S3['send']>[0]) => {
     const commandName = command.constructor.name
     const input: any = command.input
 

--- a/packages/datastore-core/package.json
+++ b/packages/datastore-core/package.json
@@ -209,7 +209,7 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-datastore": "^8.0.0",
     "interface-datastore-tests": "^5.0.0"
   },

--- a/packages/datastore-core/src/base.ts
+++ b/packages/datastore-core/src/base.ts
@@ -1,6 +1,6 @@
-import sort from 'it-sort'
 import drain from 'it-drain'
 import filter from 'it-filter'
+import sort from 'it-sort'
 import take from 'it-take'
 import type { Batch, Datastore, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import type { AbortOptions, Await, AwaitIterable } from 'interface-store'
@@ -50,16 +50,22 @@ export class BaseDatastore implements Datastore {
     let dels: Key[] = []
 
     return {
-      put (key, value) {
+      put (key: Key, value) {
         puts.push({ key, value })
       },
 
       delete (key) {
         dels.push(key)
       },
+
       commit: async (options) => {
+        // @see https://github.com/ipfs/js-stores/issues/221
+        // eslint-disable-next-line @typescript-eslint/await-thenable, @typescript-eslint/no-confusing-void-expression
         await drain(this.putMany(puts, options))
         puts = []
+
+        // @see https://github.com/ipfs/js-stores/issues/221
+        // eslint-disable-next-line @typescript-eslint/await-thenable, @typescript-eslint/no-confusing-void-expression
         await drain(this.deleteMany(dels, options))
         dels = []
       }

--- a/packages/datastore-core/src/index.ts
+++ b/packages/datastore-core/src/index.ts
@@ -1,7 +1,7 @@
-import type { Key } from 'interface-datastore'
 
 import * as Errors from './errors.js'
 import * as shard from './shard.js'
+import type { Key } from 'interface-datastore'
 
 export { BaseDatastore } from './base.js'
 export { MemoryDatastore } from './memory.js'

--- a/packages/datastore-core/src/keytransform.ts
+++ b/packages/datastore-core/src/keytransform.ts
@@ -1,6 +1,6 @@
-import { BaseDatastore } from './base.js'
 import map from 'it-map'
 import { pipe } from 'it-pipe'
+import { BaseDatastore } from './base.js'
 import type { KeyTransform } from './index.js'
 import type { Batch, Datastore, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
@@ -22,17 +22,15 @@ export class KeyTransformDatastore extends BaseDatastore {
   }
 
   async put (key: Key, val: Uint8Array, options?: AbortOptions): Promise<Key> {
-    await this.child.put(this.transform.convert(key), val, options)
-
-    return key
+    return this.child.put(this.transform.convert(key), val, options)
   }
 
   async get (key: Key, options?: AbortOptions): Promise<Uint8Array> {
-    return await this.child.get(this.transform.convert(key), options)
+    return this.child.get(this.transform.convert(key), options)
   }
 
   async has (key: Key, options?: AbortOptions): Promise<boolean> {
-    return await this.child.has(this.transform.convert(key), options)
+    return this.child.has(this.transform.convert(key), options)
   }
 
   async delete (key: Key, options?: AbortOptions): Promise<void> {

--- a/packages/datastore-core/src/memory.ts
+++ b/packages/datastore-core/src/memory.ts
@@ -1,5 +1,5 @@
-import { BaseDatastore } from './base.js'
 import { Key } from 'interface-datastore/key'
+import { BaseDatastore } from './base.js'
 import * as Errors from './errors.js'
 import type { Pair } from 'interface-datastore'
 import type { Await, AwaitIterable } from 'interface-store'

--- a/packages/datastore-core/src/mount.ts
+++ b/packages/datastore-core/src/mount.ts
@@ -1,9 +1,9 @@
 import filter from 'it-filter'
-import take from 'it-take'
 import merge from 'it-merge'
+import sort from 'it-sort'
+import take from 'it-take'
 import { BaseDatastore } from './base.js'
 import * as Errors from './errors.js'
-import sort from 'it-sort'
 import type { Batch, Datastore, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import type { AbortOptions } from 'interface-store'
 
@@ -49,20 +49,20 @@ export class MountDatastore extends BaseDatastore {
    * @param {Key} key
    * @param {Options} [options]
    */
-  async get (key: Key, options: AbortOptions = {}): Promise<Uint8Array> {
+  async get (key: Key, options?: AbortOptions): Promise<Uint8Array> {
     const match = this._lookup(key)
     if (match == null) {
       throw Errors.notFoundError(new Error('No datastore mounted for this key'))
     }
-    return await match.datastore.get(key, options)
+    return match.datastore.get(key, options)
   }
 
   async has (key: Key, options?: AbortOptions): Promise<boolean> {
     const match = this._lookup(key)
     if (match == null) {
-      return await Promise.resolve(false)
+      return Promise.resolve(false)
     }
-    return await match.datastore.has(key, options)
+    return match.datastore.has(key, options)
   }
 
   async delete (key: Key, options?: AbortOptions): Promise<void> {

--- a/packages/datastore-core/src/namespace.ts
+++ b/packages/datastore-core/src/namespace.ts
@@ -1,6 +1,6 @@
 import { Key } from 'interface-datastore'
-import type { Datastore } from 'interface-datastore'
 import { KeyTransformDatastore } from './keytransform.js'
+import type { Datastore } from 'interface-datastore'
 
 /**
  * Wraps a given datastore into a keytransform which

--- a/packages/datastore-core/src/shard.ts
+++ b/packages/datastore-core/src/shard.ts
@@ -1,6 +1,6 @@
-import type { Datastore } from 'interface-datastore'
 import { Key } from 'interface-datastore/key'
 import type { Shard } from './index.js'
+import type { Datastore } from 'interface-datastore'
 
 export const PREFIX = '/repo/flatfs/shard/'
 export const SHARDING_FN = 'SHARDING'
@@ -108,8 +108,6 @@ export function parseShardFun (str: string): Shard {
 
 export const readShardFun = async (path: string | Uint8Array, store: Datastore): Promise<Shard> => {
   const key = new Key(path).child(new Key(SHARDING_FN))
-  // @ts-expect-error
-  const get = typeof store.getRaw === 'function' ? store.getRaw.bind(store) : store.get.bind(store)
-  const res = await get(key)
+  const res = await store.get(key)
   return parseShardFun(new TextDecoder().decode(res ?? '').trim())
 }

--- a/packages/datastore-core/src/sharding.ts
+++ b/packages/datastore-core/src/sharding.ts
@@ -1,13 +1,12 @@
-import { Batch, Key, KeyQuery, KeyQueryFilter, Pair, Query, QueryFilter } from 'interface-datastore'
+import { type Batch, Key, type KeyQuery, type KeyQueryFilter, type Pair, type Query, type QueryFilter, type Datastore } from 'interface-datastore'
+import { BaseDatastore } from './base.js'
+import * as Errors from './errors.js'
+import { KeyTransformDatastore } from './keytransform.js'
 import {
   readShardFun,
   SHARDING_FN
 } from './shard.js'
-import { BaseDatastore } from './base.js'
-import { KeyTransformDatastore } from './keytransform.js'
-import * as Errors from './errors.js'
 import type { Shard } from './index.js'
-import type { Datastore } from 'interface-datastore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
 
 const shardKey = new Key(SHARDING_FN)
@@ -88,11 +87,11 @@ export class ShardingDatastore extends BaseDatastore {
   }
 
   async get (key: Key, options?: AbortOptions): Promise<Uint8Array> {
-    return await this.child.get(key, options)
+    return this.child.get(key, options)
   }
 
   async has (key: Key, options?: AbortOptions): Promise<boolean> {
-    return await this.child.has(key, options)
+    return this.child.has(key, options)
   }
 
   async delete (key: Key, options?: AbortOptions): Promise<void> {

--- a/packages/datastore-core/src/tiered.ts
+++ b/packages/datastore-core/src/tiered.ts
@@ -1,8 +1,8 @@
+import { logger } from '@libp2p/logger'
+import drain from 'it-drain'
+import { pushable } from 'it-pushable'
 import { BaseDatastore } from './base.js'
 import * as Errors from './errors.js'
-import { logger } from '@libp2p/logger'
-import { pushable } from 'it-pushable'
-import drain from 'it-drain'
 import type { Batch, Datastore, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
 
@@ -71,8 +71,7 @@ export class TieredDatastore extends BaseDatastore {
       })
 
       drain(store.putMany(source, options))
-        .catch(err => {
-          // store threw while putting, make sure we bubble the error up
+        .catch((err) => {
           error = err
         })
 
@@ -102,8 +101,7 @@ export class TieredDatastore extends BaseDatastore {
       })
 
       drain(store.deleteMany(source, options))
-        .catch(err => {
-          // store threw while deleting, make sure we bubble the error up
+        .catch((err) => {
           error = err
         })
 

--- a/packages/datastore-core/test/keytransform.spec.ts
+++ b/packages/datastore-core/test/keytransform.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import all from 'it-all'
 import { Key } from 'interface-datastore/key'
-import { MemoryDatastore } from '../src/memory.js'
+import all from 'it-all'
 import { KeyTransformDatastore } from '../src/keytransform.js'
+import { MemoryDatastore } from '../src/memory.js'
 
 describe('KeyTransformDatastore', () => {
   it('basic', async () => {
@@ -33,12 +33,12 @@ describe('KeyTransformDatastore', () => {
       'foo/bar/baz/barb'
     ].map((s) => new Key(s))
     await Promise.all(keys.map(async (key) => { await kStore.put(key, key.uint8Array()) }))
-    const kResults = Promise.all(keys.map(async (key) => await kStore.get(key)))
-    const mResults = Promise.all(keys.map(async (key) => await mStore.get(new Key('abc').child(key))))
+    const kResults = Promise.all(keys.map(async (key) => kStore.get(key)))
+    const mResults = Promise.all(keys.map(async (key) => mStore.get(new Key('abc').child(key))))
     const results = await Promise.all([kResults, mResults])
     expect(results[0]).to.eql(results[1])
 
-    const mRes = await all(mStore.query({}))
+    const mRes = await Promise.resolve(all(mStore.query({})))
     const kRes = await all(kStore.query({}))
     expect(kRes).to.have.length(mRes.length)
 

--- a/packages/datastore-core/test/memory.spec.ts
+++ b/packages/datastore-core/test/memory.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
-import { MemoryDatastore } from '../src/memory.js'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import { MemoryDatastore } from '../src/memory.js'
 
 describe('Memory', () => {
   describe('interface-datastore', () => {

--- a/packages/datastore-core/test/mount.spec.ts
+++ b/packages/datastore-core/test/mount.spec.ts
@@ -2,13 +2,13 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 
 import { expect, assert } from 'aegir/chai'
-import all from 'it-all'
 import { Key } from 'interface-datastore/key'
+import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import all from 'it-all'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { KeyTransformDatastore } from '../src/keytransform.js'
 import { MemoryDatastore } from '../src/memory.js'
 import { MountDatastore } from '../src/mount.js'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { interfaceDatastoreTests } from 'interface-datastore-tests'
-import { KeyTransformDatastore } from '../src/keytransform.js'
 import type { Datastore } from 'interface-datastore'
 
 const stripPrefixDatastore = (datastore: Datastore, prefix: Key): Datastore => {

--- a/packages/datastore-core/test/namespace.spec.ts
+++ b/packages/datastore-core/test/namespace.spec.ts
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import all from 'it-all'
 import { Key } from 'interface-datastore/key'
-import { MemoryDatastore } from '../src/memory.js'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { NamespaceDatastore } from '../src/namespace.js'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import all from 'it-all'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { MemoryDatastore } from '../src/memory.js'
+import { NamespaceDatastore } from '../src/namespace.js'
 
 describe('NamespaceDatastore', () => {
   const prefixes = [
@@ -27,10 +27,10 @@ describe('NamespaceDatastore', () => {
     ].map((s) => new Key(s))
 
     await Promise.all(keys.map(async key => { await store.put(key, uint8ArrayFromString(key.toString())) }))
-    const nResults = Promise.all(keys.map(async (key) => await store.get(key)))
-    const mResults = Promise.all(keys.map(async (key) => await mStore.get(new Key(prefix).child(key))))
+    const nResults = Promise.all(keys.map(async (key) => store.get(key)))
+    const mResults = Promise.all(keys.map(async (key) => mStore.get(new Key(prefix).child(key))))
     const results = await Promise.all([nResults, mResults])
-    const mRes = await all(mStore.query({}))
+    const mRes = await Promise.resolve(all(mStore.query({})))
     const nRes = await all(store.query({}))
 
     expect(nRes).to.have.length(mRes.length)

--- a/packages/datastore-core/test/sharding.spec.ts
+++ b/packages/datastore-core/test/sharding.spec.ts
@@ -2,9 +2,10 @@
 
 import { expect } from 'aegir/chai'
 import { Key } from 'interface-datastore/key'
-import { MemoryDatastore } from '../src/memory.js'
+import { interfaceDatastoreTests } from 'interface-datastore-tests'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { MemoryDatastore } from '../src/memory.js'
 import {
   NextToLast,
   SHARDING_FN
@@ -12,7 +13,6 @@ import {
 import {
   ShardingDatastore
 } from '../src/sharding.js'
-import { interfaceDatastoreTests } from 'interface-datastore-tests'
 
 describe('ShardingDatastore', () => {
   it('create', async () => {
@@ -28,7 +28,7 @@ describe('ShardingDatastore', () => {
 
   it('open - empty', () => {
     const ms = new MemoryDatastore()
-    // @ts-expect-error
+    // @ts-expect-error No shard is given on purpose to generate an error.
     const store = new ShardingDatastore(ms)
     return expect(store.open())
       .to.eventually.be.rejected()

--- a/packages/datastore-core/test/tiered.spec.ts
+++ b/packages/datastore-core/test/tiered.spec.ts
@@ -2,10 +2,10 @@
 
 import { expect } from 'aegir/chai'
 import { Key } from 'interface-datastore/key'
+import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { MemoryDatastore } from '../src/memory.js'
 import { TieredDatastore } from '../src/tiered.js'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { interfaceDatastoreTests } from 'interface-datastore-tests'
 import type { Datastore } from 'interface-datastore'
 
 /**

--- a/packages/datastore-fs/package.json
+++ b/packages/datastore-fs/package.json
@@ -150,7 +150,7 @@
   },
   "devDependencies": {
     "@types/mkdirp": "^2.0.0",
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-datastore-tests": "^5.0.0",
     "ipfs-utils": "^9.0.4"
   },

--- a/packages/datastore-fs/src/index.ts
+++ b/packages/datastore-fs/src/index.ts
@@ -1,17 +1,17 @@
 import fs from 'node:fs/promises'
-import glob from 'it-glob'
 import path from 'node:path'
 import { promisify } from 'util'
 import {
-  Key, KeyQuery, Pair, Query
-} from 'interface-datastore'
-import {
   BaseDatastore, Errors
 } from 'datastore-core'
-import map from 'it-map'
-import parallel from 'it-parallel-batch'
 // @ts-expect-error no types
 import fwa from 'fast-write-atomic'
+import {
+  Key, type KeyQuery, type Pair, type Query
+} from 'interface-datastore'
+import glob from 'it-glob'
+import map from 'it-map'
+import parallel from 'it-parallel-batch'
 import type { AwaitIterable } from 'interface-store'
 
 const writeAtomic = promisify(fwa)

--- a/packages/datastore-fs/test/index.spec.ts
+++ b/packages/datastore-fs/test/index.spec.ts
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
-import { expect } from 'aegir/chai'
-import path from 'node:path'
 import fs from 'node:fs/promises'
-import { Key } from 'interface-datastore'
+import path from 'node:path'
+import { expect } from 'aegir/chai'
 import { ShardingDatastore, shard } from 'datastore-core'
+import { Key } from 'interface-datastore'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
-import { FsDatastore } from '../src/index.js'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { FsDatastore } from '../src/index.js'
 
 const utf8Encoder = new TextEncoder()
 
@@ -115,7 +115,7 @@ describe('FsDatastore', () => {
     await fstore.open()
     await ShardingDatastore.create(fstore, new shard.NextToLast(2))
 
-    const file = await fs.readFile(path.join(dir, shard.SHARDING_FN + '.data'))
+    const file = await fs.readFile(path.join(dir, `${shard.SHARDING_FN}.data`))
     expect(file.toString()).to.be.eql('/repo/flatfs/shard/v1/next-to-last/2\n')
 
     await fs.rm(dir, {

--- a/packages/datastore-idb/package.json
+++ b/packages/datastore-idb/package.json
@@ -150,7 +150,7 @@
     "it-sort": "^3.0.1"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "datastore-core": "^9.0.0",
     "interface-datastore-tests": "^5.0.0"
   },

--- a/packages/datastore-idb/src/index.ts
+++ b/packages/datastore-idb/src/index.ts
@@ -1,6 +1,6 @@
-import { openDB, deleteDB, IDBPDatabase } from 'idb'
-import { Batch, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import { Errors, BaseDatastore } from 'datastore-core'
+import { openDB, deleteDB, type IDBPDatabase } from 'idb'
+import { type Batch, Key, type KeyQuery, type Pair, type Query } from 'interface-datastore'
 import filter from 'it-filter'
 import sort from 'it-sort'
 

--- a/packages/datastore-idb/test/index.spec.ts
+++ b/packages/datastore-idb/test/index.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
+import { expect } from 'aegir/chai'
 import { MountDatastore } from 'datastore-core'
 import { Key } from 'interface-datastore'
-import { IDBDatastore } from '../src/index.js'
-import { expect } from 'aegir/chai'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import { IDBDatastore } from '../src/index.js'
 
 describe('IndexedDB Datastore', function () {
   describe('interface-datastore (idb)', () => {

--- a/packages/datastore-level/package.json
+++ b/packages/datastore-level/package.json
@@ -154,7 +154,7 @@
     "level": "^8.0.0"
   },
   "devDependencies": {
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-datastore-tests": "^5.0.0",
     "ipfs-utils": "^9.0.4",
     "memory-level": "^1.0.0"

--- a/packages/datastore-level/src/index.ts
+++ b/packages/datastore-level/src/index.ts
@@ -1,9 +1,9 @@
-import { Batch, Key, KeyQuery, Pair, Query } from 'interface-datastore'
 import { BaseDatastore, Errors } from 'datastore-core'
+import { type Batch, Key, type KeyQuery, type Pair, type Query } from 'interface-datastore'
 import filter from 'it-filter'
 import map from 'it-map'
-import take from 'it-take'
 import sort from 'it-sort'
+import take from 'it-take'
 import { Level } from 'level'
 import type { DatabaseOptions, OpenOptions, IteratorOptions } from 'level'
 
@@ -232,7 +232,7 @@ function oldLevelIteratorToIterator (li: OldLevelIterator): AsyncIterable<Pair> 
   return {
     [Symbol.asyncIterator] () {
       return {
-        next: async () => await new Promise((resolve, reject) => {
+        next: async () => new Promise((resolve, reject) => {
           li.next((err, key, value) => {
             if (err != null) {
               reject(err); return
@@ -249,7 +249,7 @@ function oldLevelIteratorToIterator (li: OldLevelIterator): AsyncIterable<Pair> 
             resolve({ done: false, value: { key: new Key(key, false), value } })
           })
         }),
-        return: async () => await new Promise((resolve, reject) => {
+        return: async () => new Promise((resolve, reject) => {
           li.end(err => {
             if (err != null) {
               reject(err); return

--- a/packages/datastore-level/test/browser.ts
+++ b/packages/datastore-level/test/browser.ts
@@ -2,8 +2,8 @@
 
 import { MountDatastore } from 'datastore-core'
 import { Key } from 'interface-datastore/key'
-import { LevelDatastore } from '../src/index.js'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import { LevelDatastore } from '../src/index.js'
 
 describe('LevelDatastore', () => {
   describe('interface-datastore (leveljs)', () => {

--- a/packages/datastore-level/test/fixtures/test-level-iterator-destroy.ts
+++ b/packages/datastore-level/test/fixtures/test-level-iterator-destroy.ts
@@ -1,6 +1,6 @@
 import { Key } from 'interface-datastore/key'
-import { LevelDatastore } from '../../src/index.js'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { LevelDatastore } from '../../src/index.js'
 
 async function testLevelIteratorDestroy (): Promise<void> {
   const store = new LevelDatastore(tempdir())

--- a/packages/datastore-level/test/index.spec.ts
+++ b/packages/datastore-level/test/index.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { MemoryLevel } from 'memory-level'
-import { Level } from 'level'
-import { LevelDatastore } from '../src/index.js'
-import tempdir from 'ipfs-utils/src/temp-dir.js'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { Level } from 'level'
+import { MemoryLevel } from 'memory-level'
+import { LevelDatastore } from '../src/index.js'
 
 describe('LevelDatastore', () => {
   describe('initialization', () => {

--- a/packages/datastore-level/test/node.ts
+++ b/packages/datastore-level/test/node.ts
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
 
-import { expect } from 'aegir/chai'
-import path from 'path'
-import { Key } from 'interface-datastore/key'
-import { MountDatastore } from 'datastore-core'
 import childProcess from 'child_process'
+import path from 'path'
+import { expect } from 'aegir/chai'
+import { MountDatastore } from 'datastore-core'
+import { Key } from 'interface-datastore/key'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
-import { LevelDatastore } from '../src/index.js'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
+import { LevelDatastore } from '../src/index.js'
 
 describe('LevelDatastore', () => {
   describe('interface-datastore (leveldown)', () => {

--- a/packages/datastore-s3/package.json
+++ b/packages/datastore-s3/package.json
@@ -152,7 +152,7 @@
   },
   "devDependencies": {
     "@types/sinon": "^10.0.15",
-    "aegir": "^38.1.7",
+    "aegir": "^39.0.8",
     "interface-datastore-tests": "^5.0.0",
     "p-defer": "^4.0.0",
     "sinon": "^15.0.2"

--- a/packages/datastore-s3/package.json
+++ b/packages/datastore-s3/package.json
@@ -151,6 +151,7 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
+    "@types/sinon": "^10.0.15",
     "aegir": "^38.1.7",
     "interface-datastore-tests": "^5.0.0",
     "p-defer": "^4.0.0",

--- a/packages/datastore-s3/src/index.ts
+++ b/packages/datastore-s3/src/index.ts
@@ -1,11 +1,3 @@
-import filter from 'it-filter'
-import { Key, KeyQuery, Pair, Query } from 'interface-datastore'
-import { BaseDatastore } from 'datastore-core/base'
-import * as Errors from 'datastore-core/errors'
-import { fromString as unint8arrayFromString } from 'uint8arrays'
-import toBuffer from 'it-to-buffer'
-import type { S3 } from '@aws-sdk/client-s3'
-import type { AbortOptions } from 'interface-store'
 import {
   PutObjectCommand,
   CreateBucketCommand,
@@ -14,6 +6,13 @@ import {
   DeleteObjectCommand,
   ListObjectsV2Command
 } from '@aws-sdk/client-s3'
+import { BaseDatastore, Errors } from 'datastore-core'
+import { Key, type KeyQuery, type Pair, type Query } from 'interface-datastore'
+import filter from 'it-filter'
+import toBuffer from 'it-to-buffer'
+import { fromString as unint8arrayFromString } from 'uint8arrays'
+import type { S3 } from '@aws-sdk/client-s3'
+import type { AbortOptions } from 'interface-store'
 
 export interface S3DatastoreInit {
   /**

--- a/packages/datastore-s3/test/index.spec.ts
+++ b/packages/datastore-s3/test/index.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-env mocha */
 
+import { type CreateBucketCommand, type PutObjectCommand, type HeadObjectCommand, S3, type GetObjectCommand } from '@aws-sdk/client-s3'
 import { expect } from 'aegir/chai'
-import sinon from 'sinon'
 import { Key } from 'interface-datastore'
-import { CreateBucketCommand, PutObjectCommand, HeadObjectCommand, S3, GetObjectCommand } from '@aws-sdk/client-s3'
-import defer from 'p-defer'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
-
-import { s3Resolve, s3Reject, S3Error, s3Mock } from './utils/s3-mock.js'
+import defer from 'p-defer'
+import sinon from 'sinon'
 import { S3Datastore } from '../src/index.js'
+import { s3Resolve, s3Reject, S3Error, s3Mock } from './utils/s3-mock.js'
 
 describe('S3Datastore', () => {
   describe('construction', () => {

--- a/packages/datastore-s3/test/utils/s3-mock.ts
+++ b/packages/datastore-s3/test/utils/s3-mock.ts
@@ -30,9 +30,9 @@ export const s3Reject = <T> (err: T): any => {
  */
 export function s3Mock (s3: S3): S3 {
   const mocks: any = {}
-  const storage: Map<string, any> = new Map()
+  const storage = new Map<string, any>()
 
-  mocks.send = sinon.replace(s3, 'send', (command) => {
+  mocks.send = sinon.replace(s3, 'send', (command: Parameters<S3['send']>[0]) => {
     const commandName = command.constructor.name
     const input: any = command.input
 

--- a/packages/interface-blockstore-tests/package.json
+++ b/packages/interface-blockstore-tests/package.json
@@ -134,12 +134,14 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "aegir": "^38.1.0",
     "interface-blockstore": "^5.0.0",
     "it-all": "^3.0.1",
     "it-drain": "^3.0.1",
     "multiformats": "^11.0.2",
     "uint8arrays": "^4.0.2"
+  },
+  "devDependencies": {
+    "aegir": "^39.0.8"
   },
   "typedoc": {
     "entryPoint": "./src/index.js"

--- a/packages/interface-blockstore-tests/src/index.ts
+++ b/packages/interface-blockstore-tests/src/index.ts
@@ -3,12 +3,12 @@
 import { expect } from 'aegir/chai'
 import all from 'it-all'
 import drain from 'it-drain'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { sha256 } from 'multiformats/hashes/sha2'
-import type { Blockstore, Pair } from 'interface-blockstore'
 import { base32 } from 'multiformats/bases/base32'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import type { Blockstore, Pair } from 'interface-blockstore'
 
 async function getKeyValuePair (data?: string): Promise<Pair> {
   const block = uint8ArrayFromString(data ?? `data-${Math.random()}`)
@@ -19,8 +19,8 @@ async function getKeyValuePair (data?: string): Promise<Pair> {
 }
 
 async function getKeyValuePairs (count: number): Promise<Pair[]> {
-  return await Promise.all(
-    new Array(count).fill(0).map(async (_, i) => await getKeyValuePair())
+  return Promise.all(
+    new Array(count).fill(0).map(async (_, i) => getKeyValuePair())
   )
 }
 
@@ -66,7 +66,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       await Promise.all(data.map(async d => { await store.put(d.cid, d.block) }))
 
-      const res = await all(store.getMany(data.map(d => d.cid)))
+      const res = await Promise.resolve(all(store.getMany(data.map(d => d.cid))))
       expect(res).to.deep.equal(data)
     })
   })
@@ -94,7 +94,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       expect(index).to.equal(data.length)
 
-      const res = await all(store.getMany(data.map(d => d.cid)))
+      const res = await Promise.resolve(all(store.getMany(data.map(d => d.cid))))
       expect(res).to.deep.equal(data)
     })
   })
@@ -156,7 +156,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
       await store.put(cid, block)
       const source = [cid]
 
-      const res = await all(store.getMany(source))
+      const res = await Promise.resolve(all(store.getMany(source)))
       expect(res).to.have.lengthOf(1)
       expect(res[0].cid).to.deep.equal(cid)
       expect(res[0].block).to.equalBytes(block)
@@ -168,7 +168,8 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
       } = await getKeyValuePair()
 
       try {
-        await drain(store.getMany([cid]))
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+        await Promise.resolve(drain(store.getMany([cid])))
       } catch (err) {
         expect(err).to.have.property('code', 'ERR_NOT_FOUND')
         return
@@ -192,9 +193,10 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
     it('returns all blocks', async () => {
       const data = await getKeyValuePairs(100)
 
-      await drain(store.putMany(data))
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      await Promise.resolve(drain(store.putMany(data)))
 
-      const allBlocks = await all(store.getAll())
+      const allBlocks = await Promise.resolve(all(store.getAll()))
 
       expect(allBlocks).of.have.lengthOf(data.length)
 
@@ -243,12 +245,12 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       await Promise.all(data.map(async d => { await store.put(d.cid, d.block) }))
 
-      const res0 = await Promise.all(data.map(async d => await store.has(d.cid)))
+      const res0 = await Promise.all(data.map(async d => store.has(d.cid)))
       res0.forEach(res => expect(res).to.be.eql(true))
 
       await Promise.all(data.map(async d => { await store.delete(d.cid) }))
 
-      const res1 = await Promise.all(data.map(async d => await store.has(d.cid)))
+      const res1 = await Promise.all(data.map(async d => store.has(d.cid)))
       res1.forEach(res => expect(res).to.be.eql(false))
     })
   })
@@ -267,9 +269,10 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
     it('streaming', async () => {
       const data = await getKeyValuePairs(100)
 
-      await drain(store.putMany(data))
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      await Promise.resolve(drain(store.putMany(data)))
 
-      const res0 = await Promise.all(data.map(async d => await store.has(d.cid)))
+      const res0 = await Promise.all(data.map(async d => store.has(d.cid)))
       res0.forEach(res => expect(res).to.be.eql(true))
 
       let index = 0
@@ -281,7 +284,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       expect(index).to.equal(data.length)
 
-      const res1 = await Promise.all(data.map(async d => await store.has(d.cid)))
+      const res1 = await Promise.all(data.map(async d => store.has(d.cid)))
       res1.forEach(res => expect(res).to.be.eql(false))
     })
   })

--- a/packages/interface-blockstore/package.json
+++ b/packages/interface-blockstore/package.json
@@ -131,7 +131,7 @@
     "multiformats": "^11.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7"
+    "aegir": "^39.0.8"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"

--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -10,10 +10,10 @@ export interface Pair {
   block: Uint8Array
 }
 
-export interface Blockstore <HasOptionsExtension = {},
-PutOptionsExtension = {}, PutManyOptionsExtension = {},
-GetOptionsExtension = {}, GetManyOptionsExtension = {}, GetAllOptionsExtension = {},
-DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {}> extends Store<CID, Uint8Array, Pair, HasOptionsExtension,
+export interface Blockstore <HasOptionsExtension = unknown,
+PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
+GetOptionsExtension = unknown, GetManyOptionsExtension = unknown, GetAllOptionsExtension = unknown,
+DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown> extends Store<CID, Uint8Array, Pair, HasOptionsExtension,
   PutOptionsExtension, PutManyOptionsExtension,
   GetOptionsExtension, GetManyOptionsExtension,
   DeleteOptionsExtension, DeleteManyOptionsExtension> {

--- a/packages/interface-datastore-tests/package.json
+++ b/packages/interface-datastore-tests/package.json
@@ -134,13 +134,15 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "aegir": "^38.1.0",
     "interface-datastore": "^8.0.0",
     "iso-random-stream": "^2.0.0",
     "it-all": "^3.0.1",
     "it-drain": "^3.0.1",
     "it-length": "^3.0.1",
     "uint8arrays": "^4.0.2"
+  },
+  "devDependencies": {
+    "aegir": "^39.0.8"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"

--- a/packages/interface-datastore/package.json
+++ b/packages/interface-datastore/package.json
@@ -165,7 +165,7 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "aegir": "^38.1.7"
+    "aegir": "^39.0.8"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"

--- a/packages/interface-datastore/src/index.ts
+++ b/packages/interface-datastore/src/index.ts
@@ -1,28 +1,28 @@
+import { Key } from './key.js'
 import type {
   Await,
   AwaitIterable,
   Store,
   AbortOptions
 } from 'interface-store'
-import { Key } from './key.js'
 
 export interface Pair {
   key: Key
   value: Uint8Array
 }
 
-export interface Batch<BatchOptionsExtension = {}> {
+export interface Batch<BatchOptionsExtension = unknown> {
   put: (key: Key, value: Uint8Array) => void
   delete: (key: Key) => void
   commit: (options?: AbortOptions & BatchOptionsExtension) => Await<void>
 }
 
-export interface Datastore <HasOptionsExtension = {},
-PutOptionsExtension = {}, PutManyOptionsExtension = {},
-GetOptionsExtension = {}, GetManyOptionsExtension = {},
-DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {},
-QueryOptionsExtension = {}, QueryKeysOptionsExtension = {},
-BatchOptionsExtension = {}
+export interface Datastore <HasOptionsExtension = unknown,
+PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
+GetOptionsExtension = unknown, GetManyOptionsExtension = unknown,
+DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown,
+QueryOptionsExtension = unknown, QueryKeysOptionsExtension = unknown,
+BatchOptionsExtension = unknown,
 > extends Store<Key, Uint8Array, Pair, HasOptionsExtension,
   PutOptionsExtension, PutManyOptionsExtension,
   GetOptionsExtension, GetManyOptionsExtension,

--- a/packages/interface-datastore/src/key.ts
+++ b/packages/interface-datastore/src/key.ts
@@ -1,7 +1,7 @@
 
 import { nanoid } from 'nanoid'
-import { SupportedEncodings, toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { type SupportedEncodings, toString as uint8ArrayToString } from 'uint8arrays/to-string'
 
 const pathSepS = '/'
 const pathSepB = new TextEncoder().encode(pathSepS)
@@ -385,7 +385,6 @@ export class Key {
    * Checks if this key has only one namespace.
    *
    * @returns {boolean}
-   *
    */
   isTopLevel (): boolean {
     return this.list().length === 1

--- a/packages/interface-datastore/test/key.spec.ts
+++ b/packages/interface-datastore/test/key.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { Key } from '../src/key.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays'
+import { Key } from '../src/key.js'
 
 const pathSep = '/'
 

--- a/packages/interface-store/package.json
+++ b/packages/interface-store/package.json
@@ -130,7 +130,7 @@
     "release": "aegir release"
   },
   "devDependencies": {
-    "aegir": "^38.1.7"
+    "aegir": "^39.0.8"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"

--- a/packages/interface-store/src/index.ts
+++ b/packages/interface-store/src/index.ts
@@ -16,10 +16,10 @@ export interface AbortOptions {
   signal?: AbortSignal
 }
 
-export interface Store<Key, Value, Pair, HasOptionsExtension = {},
-  PutOptionsExtension = {}, PutManyOptionsExtension = {},
-  GetOptionsExtension = {}, GetManyOptionsExtension = {},
-  DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {}> {
+export interface Store<Key, Value, Pair, HasOptionsExtension = unknown,
+  PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
+  GetOptionsExtension = unknown, GetManyOptionsExtension = unknown,
+  DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown> {
   /**
    * Check for the existence of a value for the passed key
    *


### PR DESCRIPTION
This PR is the culmination of #221 in an effort to upgrade js-stores to use the latest version of aegir.

Dependabot was unable to update to the latest version of aegir due to linting issues. These are similar to the issues that helia ran into a few weeks ago (see: https://github.com/ipfs/helia/pull/111).

This PR namely bumps aegir's version and fixes the resulting linting errors that followed.