### PR TITLE
docs: Update Blockstore and Datastore implementation lists

### DIFF
--- a/packages/interface-blockstore/README.md
+++ b/packages/interface-blockstore/README.md
@@ -10,6 +10,7 @@
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+- [Implementations](#implementations)
 - [API Docs](#api-docs)
 - [License](#license)
 - [Contribute](#contribute)
@@ -19,6 +20,14 @@
 ```console
 $ npm i interface-blockstore
 ```
+
+## Implementations
+
+- File System: [`blockstore-fs`](https://github.com/ipfs/js-stores/tree/main/packages/blockstore-fs)
+- IndexedDB: [`blockstore-idb`](https://github.com/ipfs/js-stores/blob/main/packages/blockstore-idb)
+- level: [`blockstore-level`](https://github.com/ipfs/js-stores/tree/main/packages/blockstore-level) (supports any levelup compatible backend)
+- Memory: [`blockstore-core/memory`](https://github.com/ipfs/js-stores/blob/main/packages/blockstore-core/src/memory.ts)
+- S3: [`blockstore-s3`](https://github.com/ipfs/js-stores/tree/main/packages/blockstore-s3)
 
 ## API Docs
 

--- a/packages/interface-datastore/README.md
+++ b/packages/interface-datastore/README.md
@@ -39,6 +39,7 @@ Loading this module through a script tag will make it's exports available as `In
 
 - Backed Implementations
   - File System: [`datastore-fs`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-fs)
+  - IndexedDB: [`datastore-idb`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-idb)
   - level: [`datastore-level`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-level) (supports any levelup compatible backend)
   - Memory: [`datastore-core/memory`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/memory.ts)
   - S3: [`datastore-s3`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-s3)

--- a/packages/interface-datastore/README.md
+++ b/packages/interface-datastore/README.md
@@ -38,16 +38,16 @@ Loading this module through a script tag will make it's exports available as `In
 ## Implementations
 
 - Backed Implementations
-  - Memory: [`datastore-core/memory`](https://github.com/ipfs/js-datastore-core/tree/master/src/memory.js)
-  - level: [`datastore-level`](https://github.com/ipfs/js-datastore-level) (supports any levelup compatible backend)
-  - File System: [`datstore-fs`](https://github.com/ipfs/js-datastore-fs)
-  - S3: [`datstore-s3`](https://github.com/ipfs/js-datastore-s3)
+  - File System: [`datastore-fs`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-fs)
+  - level: [`datastore-level`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-level) (supports any levelup compatible backend)
+  - Memory: [`datastore-core/memory`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/memory.ts)
+  - S3: [`datastore-s3`](https://github.com/ipfs/js-stores/tree/main/packages/datastore-s3)
 - Wrapper Implementations
-  - Mount: [`datastore-core/src/mount`](https://github.com/ipfs/js-datastore-core/tree/master/src/mount.js)
-  - Keytransform: [`datstore-core/src/keytransform`](https://github.com/ipfs/js-datastore-core/tree/master/src/keytransform.js)
-  - Sharding: [`datastore-core/src/sharding`](https://github.com/ipfs/js-datastore-core/tree/master/src/sharding.js)
-  - Tiered: [`datstore-core/src/tiered`](https://github.com/ipfs/js-datastore-core/blob/master/src/tiered.js)
-  - Namespace: [`datastore-core/src/namespace`](https://github.com/ipfs/js-datastore-core/tree/master/src/namespace.js)
+  - Keytransform: [`datstore-core/src/keytransform`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/keytransform.ts)
+  - Mount: [`datastore-core/src/mount`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/mount.ts)
+  - Namespace: [`datastore-core/src/namespace`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/namespace.ts)
+  - Sharding: [`datastore-core/src/sharding`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/sharding.ts)
+  - Tiered: [`datstore-core/src/tiered`](https://github.com/ipfs/js-stores/blob/main/packages/datastore-core/src/tiered.ts)
 
 If you want the same functionality as [go-ds-flatfs](https://github.com/ipfs/go-ds-flatfs), use sharding with fs.
 


### PR DESCRIPTION
The links in the Datastore interface were out of date.

Took the opportunity to add an implementation list to the Blockstore interface while I was at it.