### PR TITLE
fix: restore empty object default

### DIFF
--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
+// this ignore is so we can use {} as the default value for the options
+// extensions below - it normally means "any non-nullish value" but here
+// we are using it as an intersection type - see the aside at the bottom:
+// https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
 
 import type {
   AbortOptions,

--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import type {
   AbortOptions,
   AwaitIterable,
@@ -10,10 +12,10 @@ export interface Pair {
   block: Uint8Array
 }
 
-export interface Blockstore <HasOptionsExtension = unknown,
-PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
-GetOptionsExtension = unknown, GetManyOptionsExtension = unknown, GetAllOptionsExtension = unknown,
-DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown> extends Store<CID, Uint8Array, Pair, HasOptionsExtension,
+export interface Blockstore <HasOptionsExtension = {},
+PutOptionsExtension = {}, PutManyOptionsExtension = {},
+GetOptionsExtension = {}, GetManyOptionsExtension = {}, GetAllOptionsExtension = {},
+DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {}> extends Store<CID, Uint8Array, Pair, HasOptionsExtension,
   PutOptionsExtension, PutManyOptionsExtension,
   GetOptionsExtension, GetManyOptionsExtension,
   DeleteOptionsExtension, DeleteManyOptionsExtension> {

--- a/packages/interface-datastore/src/index.ts
+++ b/packages/interface-datastore/src/index.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
+// this ignore is so we can use {} as the default value for the options
+// extensions below - it normally means "any non-nullish value" but here
+// we are using it as an intersection type - see the aside at the bottom:
+// https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
 
 import { Key } from './key.js'
 import type {

--- a/packages/interface-datastore/src/index.ts
+++ b/packages/interface-datastore/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import { Key } from './key.js'
 import type {
   Await,
@@ -11,18 +13,18 @@ export interface Pair {
   value: Uint8Array
 }
 
-export interface Batch<BatchOptionsExtension = unknown> {
+export interface Batch<BatchOptionsExtension = {}> {
   put: (key: Key, value: Uint8Array) => void
   delete: (key: Key) => void
   commit: (options?: AbortOptions & BatchOptionsExtension) => Await<void>
 }
 
-export interface Datastore <HasOptionsExtension = unknown,
-PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
-GetOptionsExtension = unknown, GetManyOptionsExtension = unknown,
-DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown,
-QueryOptionsExtension = unknown, QueryKeysOptionsExtension = unknown,
-BatchOptionsExtension = unknown
+export interface Datastore <HasOptionsExtension = {},
+PutOptionsExtension = {}, PutManyOptionsExtension = {},
+GetOptionsExtension = {}, GetManyOptionsExtension = {},
+DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {},
+QueryOptionsExtension = {}, QueryKeysOptionsExtension = {},
+BatchOptionsExtension = {}
 > extends Store<Key, Uint8Array, Pair, HasOptionsExtension,
   PutOptionsExtension, PutManyOptionsExtension,
   GetOptionsExtension, GetManyOptionsExtension,

--- a/packages/interface-store/src/index.ts
+++ b/packages/interface-store/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 
 /**
  * An iterable or async iterable of values
@@ -16,10 +17,10 @@ export interface AbortOptions {
   signal?: AbortSignal
 }
 
-export interface Store<Key, Value, Pair, HasOptionsExtension = unknown,
-  PutOptionsExtension = unknown, PutManyOptionsExtension = unknown,
-  GetOptionsExtension = unknown, GetManyOptionsExtension = unknown,
-  DeleteOptionsExtension = unknown, DeleteManyOptionsExtension = unknown> {
+export interface Store<Key, Value, Pair, HasOptionsExtension = {},
+  PutOptionsExtension = {}, PutManyOptionsExtension = {},
+  GetOptionsExtension = {}, GetManyOptionsExtension = {},
+  DeleteOptionsExtension = {}, DeleteManyOptionsExtension = {}> {
   /**
    * Check for the existence of a value for the passed key
    *

--- a/packages/interface-store/src/index.ts
+++ b/packages/interface-store/src/index.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
+// this ignore is so we can use {} as the default value for the options
+// extensions below - it normally means "any non-nullish value" but here
+// we are using it as an intersection type - see the aside at the bottom:
+// https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
 
 /**
  * An iterable or async iterable of values


### PR DESCRIPTION
To make the type opt-in restore the empty object, otherwise extending classes become very verbose.