### PR TITLE
docs: fix capitalization in readme of datastore-fs.

### DIFF
--- a/packages/datastore-fs/README.md
+++ b/packages/datastore-fs/README.md
@@ -24,9 +24,9 @@ $ npm i datastore-fs
 ## Usage
 
 ```js
-import { FSDatastore } from 'datastore-fs'
+import { FsDatastore } from 'datastore-fs'
 
-const store = new FSDatastore('path/to/store')
+const store = new FsDatastore('path/to/store')
 ```
 
 ## API Docs


### PR DESCRIPTION
This PR fixes the capitalization of the import of `FsDatastore` in the readme.