### PR TITLE
fix: incorrect export path

### DIFF
--- a/packages/blockstore-s3/package.json
+++ b/packages/blockstore-s3/package.json
@@ -29,7 +29,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {

--- a/packages/datastore-s3/package.json
+++ b/packages/datastore-s3/package.json
@@ -29,7 +29,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
## What

Currently, `datastore-s3` and `blockstore-s3` cannot be used due to incorrect export path.

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'node_modules/datastore-s3/src/index.js'
```