### PR TITLE
fix: cleanup references to datastore in blockstores

### DIFF
--- a/packages/blockstore-core/test/tiered.spec.ts
+++ b/packages/blockstore-core/test/tiered.spec.ts
@@ -54,7 +54,7 @@ describe('Tiered', () => {
     })
   })
 
-  describe('inteface-datastore-single', () => {
+  describe('inteface-blockstore-single', () => {
     interfaceBlockstoreTests({
       setup () {
         return new TieredBlockstore([

--- a/packages/blockstore-fs/src/index.ts
+++ b/packages/blockstore-fs/src/index.ts
@@ -257,7 +257,7 @@ export class FsBlockstore implements Blockstore {
 
         yield pair
       } catch (err: any) {
-        // if keys are removed from the datastore while the query is
+        // if keys are removed from the blockstore while the query is
         // running, we may encounter missing files.
         if (err.code !== 'ENOENT') {
           throw err

--- a/packages/blockstore-idb/src/index.ts
+++ b/packages/blockstore-idb/src/index.ts
@@ -25,7 +25,7 @@ import type { Pair } from 'interface-blockstore'
 import type { AbortOptions, AwaitIterable } from 'interface-store'
 import type { MultibaseCodec } from 'multiformats/bases/interface'
 
-export interface IDBDatastoreInit {
+export interface IDBBlockstoreInit {
   /**
    * A prefix to use for all database keys (default: '')
    */
@@ -49,7 +49,7 @@ export class IDBBlockstore extends BaseBlockstore {
   private db?: IDBPDatabase
   private readonly base: MultibaseCodec<string>
 
-  constructor (location: string, init: IDBDatastoreInit = {}) {
+  constructor (location: string, init: IDBBlockstoreInit = {}) {
     super()
 
     this.location = `${init.prefix ?? ''}${location}`

--- a/packages/blockstore-level/src/index.ts
+++ b/packages/blockstore-level/src/index.ts
@@ -34,7 +34,7 @@ export interface LevelBlockstoreInit extends DatabaseOptions<string, Uint8Array>
 }
 
 /**
- * A datastore backed by leveldb
+ * A blockstore backed by leveldb
  */
 export class LevelBlockstore extends BaseBlockstore {
   public db: Level<string, Uint8Array>

--- a/packages/blockstore-level/test/node.ts
+++ b/packages/blockstore-level/test/node.ts
@@ -7,7 +7,7 @@ import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
 import tempdir from 'ipfs-utils/src/temp-dir.js'
 import { LevelBlockstore } from '../src/index.js'
 
-describe('LevelDatastore', () => {
+describe('LevelBlockstore', () => {
   describe('interface-blockstore (leveldown)', () => {
     interfaceBlockstoreTests({
       async setup () {

--- a/packages/blockstore-s3/README.md
+++ b/packages/blockstore-s3/README.md
@@ -28,7 +28,7 @@ const s3 = new S3({
 const store = new S3Blockstore(
   s3,
   'my-bucket',
-  { path: '.ipfs/blockstore', createIfMissing: false }
+  { createIfMissing: false }
 )
 ```
 

--- a/packages/blockstore-s3/README.md
+++ b/packages/blockstore-s3/README.md
@@ -14,14 +14,22 @@ A Blockstore implementation that stores blocks on Amazon S3.
 If the flag `createIfMissing` is not set or is false, then the bucket must be created prior to using blockstore-s3. Please see the AWS docs for information on how to configure the S3 instance. A bucket name is required to be set at the s3 instance level, see the below example.
 
 ```js
-import S3 from 'aws-sdk/clients/s3.js'
+import { S3 } from '@aws-sdk/client-s3'
 import { S3Blockstore } from 'blockstore-s3'
 
-const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
-const store = new S3Blockstore('.ipfs/blockstore', {
-  s3: s3Instance
-  createIfMissing: false
+const s3 = new S3({
+  region: 'region',
+  credentials: {
+    accessKeyId: 'myaccesskey',
+    secretAccessKey: 'mysecretkey'
+  }
 })
+
+const store = new S3Blockstore(
+  s3,
+  'my-bucket',
+  { path: '.ipfs/blockstore', createIfMissing: false }
+)
 ```
 
 ## Example

--- a/packages/blockstore-s3/README.md
+++ b/packages/blockstore-s3/README.md
@@ -18,7 +18,7 @@ import S3 from 'aws-sdk/clients/s3.js'
 import { S3Blockstore } from 'blockstore-s3'
 
 const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
-const store = new S3Blockstore('.ipfs/datastore', {
+const store = new S3Blockstore('.ipfs/blockstore', {
   s3: s3Instance
   createIfMissing: false
 })

--- a/packages/blockstore-s3/examples/helia/README.md
+++ b/packages/blockstore-s3/examples/helia/README.md
@@ -1,7 +1,7 @@
 Use with Helia
 ======
 
-This example uses a Datastore S3 instance to serve as the entire backend for Helia.
+This example uses a Blockstore S3 instance to serve as the entire backend for Helia.
 
 ## Running
 The S3 parameters must be updated with an existing Bucket and credentials with access to it:
@@ -15,7 +15,7 @@ const s3 = new S3({
   }
 })
 
-const datastore = new DatastoreS3(s3, 'my-bucket')
+const blockstore = new BlockstoreS3(s3, 'my-bucket')
 ```
 
 Once the S3 instance has its needed data, you can run the example:

--- a/packages/blockstore-s3/examples/helia/index.js
+++ b/packages/blockstore-s3/examples/helia/index.js
@@ -2,7 +2,7 @@ import { createHelia } from 'helia'
 import { unixfs } from '@helia/unixfs'
 import toBuffer from 'it-to-buffer'
 import { S3 } from '@aws-sdk/client-s3'
-import { DatastoreS3 } from 'datastore-s3'
+import { BlockstoreS3 } from 'blockstore-s3'
 
 async function main () {
   // Configure S3 as normal
@@ -14,12 +14,12 @@ async function main () {
     }
   })
 
-  const datastore = new DatastoreS3(s3, 'my-bucket')
+  const blockstore = new BlockstoreS3(s3, 'my-bucket')
 
   // Create a new Helia node with our S3 backed Repo
   console.log('Start Helia')
   const node = await createHelia({
-    datastore
+    blockstore
   })
 
   // Test out the repo by sending and fetching some data

--- a/packages/blockstore-s3/examples/helia/package.json
+++ b/packages/blockstore-s3/examples/helia/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.297.0",
     "@helia/unixfs": "^1.2.0",
-    "datastore-s3": "../../",
+    "blockstore-s3": "../../",
     "helia": "^1.0.0",
     "it-to-buffer": "^3.0.1"
   }

--- a/packages/blockstore-s3/package.json
+++ b/packages/blockstore-s3/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ipfs/js-stores/issues"
   },
   "keywords": [
-    "datastore",
+    "blockstore",
     "interface",
     "ipfs",
     "key-value",

--- a/packages/blockstore-s3/src/index.ts
+++ b/packages/blockstore-s3/src/index.ts
@@ -8,14 +8,22 @@
  * If the flag `createIfMissing` is not set or is false, then the bucket must be created prior to using blockstore-s3. Please see the AWS docs for information on how to configure the S3 instance. A bucket name is required to be set at the s3 instance level, see the below example.
  *
  * ```js
- * import S3 from 'aws-sdk/clients/s3.js'
+ * import { S3 } from '@aws-sdk/client-s3'
  * import { S3Blockstore } from 'blockstore-s3'
  *
- * const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
- * const store = new S3Blockstore('.ipfs/datastore', {
- *   s3: s3Instance
- *   createIfMissing: false
+ * const s3 = new S3({
+ *   region: 'region',
+ *   credentials: {
+ *     accessKeyId: 'myaccesskey',
+ *     secretAccessKey: 'mysecretkey'
+ *   }
  * })
+ *
+ * const store = new S3Blockstore(
+ *   s3,
+ *   'my-bucket',
+ *   { createIfMissing: false }
+ * )
  * ```
  *
  * @example Using with Helia

--- a/packages/blockstore-s3/test/utils/s3-mock.ts
+++ b/packages/blockstore-s3/test/utils/s3-mock.ts
@@ -26,7 +26,7 @@ export const s3Reject = <T> (err: T): any => {
 }
 
 /**
- * Mocks out the s3 calls made by datastore-s3
+ * Mocks out the s3 calls made by blockstore-s3
  */
 export function s3Mock (s3: S3): S3 {
   const mocks: any = {}

--- a/packages/datastore-idb/src/index.ts
+++ b/packages/datastore-idb/src/index.ts
@@ -96,7 +96,7 @@ export class IDBDatastore extends BaseDatastore {
 
   async has (key: Key): Promise<boolean> {
     if (this.db == null) {
-      throw new Error('Blockstore needs to be opened.')
+      throw new Error('Datastore needs to be opened.')
     }
 
     try {

--- a/packages/datastore-s3/README.md
+++ b/packages/datastore-s3/README.md
@@ -14,14 +14,22 @@ A Datastore implementation that stores data on Amazon S3.
 If the flag `createIfMissing` is not set or is false, then the bucket must be created prior to using datastore-s3. Please see the AWS docs for information on how to configure the S3 instance. A bucket name is required to be set at the s3 instance level, see the below example.
 
 ```js
-import S3 from 'aws-sdk/clients/s3.js'
+import { S3 } from '@aws-sdk/client-s3'
 import { S3Datastore } from 'datastore-s3'
 
-const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
-const store = new S3Datastore('.ipfs/datastore', {
-  s3: s3Instance
-  createIfMissing: false
+const s3 = new S3({
+  region: 'region',
+  credentials: {
+    accessKeyId: 'myaccesskey',
+    secretAccessKey: 'mysecretkey'
+  }
 })
+
+const store = new DatastoreS3(
+  s3,
+  'my-bucket',
+  { path: '.ipfs/datastore', createIfMissing: false }
+)
 ```
 
 ## Example

--- a/packages/datastore-s3/README.md
+++ b/packages/datastore-s3/README.md
@@ -25,7 +25,7 @@ const s3 = new S3({
   }
 })
 
-const store = new DatastoreS3(
+const store = new S3Datastore(
   s3,
   'my-bucket',
   { path: '.ipfs/datastore', createIfMissing: false }

--- a/packages/datastore-s3/src/index.ts
+++ b/packages/datastore-s3/src/index.ts
@@ -8,14 +8,22 @@
  * If the flag `createIfMissing` is not set or is false, then the bucket must be created prior to using datastore-s3. Please see the AWS docs for information on how to configure the S3 instance. A bucket name is required to be set at the s3 instance level, see the below example.
  *
  * ```js
- * import S3 from 'aws-sdk/clients/s3.js'
+ * import { S3 } from '@aws-sdk/client-s3'
  * import { S3Datastore } from 'datastore-s3'
  *
- * const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
- * const store = new S3Datastore('.ipfs/datastore', {
- *   s3: s3Instance
- *   createIfMissing: false
+ * const s3 = new S3({
+ *   region: 'region',
+ *   credentials: {
+ *     accessKeyId: 'myaccesskey',
+ *     secretAccessKey: 'mysecretkey'
+ *   }
  * })
+ *
+ * const store = new S3Datastore(
+ *   s3,
+ *   'my-bucket',
+ *   { path: '.ipfs/datastore', createIfMissing: false }
+ * )
  * ```
  *
  * @example Using with Helia


### PR DESCRIPTION
# What

Docs code comments and specs refer to datastores within blockstore packages.

Theres also as small change to an error and exported type https://github.com/ipfs/js-stores/commit/e3302b697c97db7f8add70bb1ab9530cfa7ff928