### PR TITLE
Fix import links

### DIFF
--- a/packages/blockstore-s3/package.json
+++ b/packages/blockstore-s3/package.json
@@ -29,7 +29,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {

--- a/packages/datastore-s3/package.json
+++ b/packages/datastore-s3/package.json
@@ -29,7 +29,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
Currently, importing from commonjs environments fails since the linked files don't exist (either in source nor in build).

This fixes the links.