### PR TITLE
fix: stop namespaced datastore throwing when queried

### DIFF
--- a/packages/datastore-core/src/namespace.ts
+++ b/packages/datastore-core/src/namespace.ts
@@ -43,7 +43,7 @@ export class NamespaceDatastore extends KeyTransformDatastore {
     }
 
     query.filters = (query.filters ?? []).map(filter => {
-      return ({ key, value }) => filter({ key: this.transform.convert(key), value })
+      return ({ key, value }) => filter({ key: this.transform.invert(key), value })
     })
 
     const { prefix } = q
@@ -79,7 +79,7 @@ export class NamespaceDatastore extends KeyTransformDatastore {
     }
 
     query.filters = (query.filters ?? []).map(filter => {
-      return (key) => filter(this.transform.convert(key))
+      return (key) => filter(this.transform.invert(key))
     })
 
     const { prefix } = q

--- a/packages/datastore-core/src/namespace.ts
+++ b/packages/datastore-core/src/namespace.ts
@@ -1,6 +1,7 @@
-import { Key } from 'interface-datastore'
+import { Key, type Datastore, type Query, type Pair, type KeyQuery } from 'interface-datastore'
+import map from 'it-map'
 import { KeyTransformDatastore } from './keytransform.js'
-import type { Datastore } from 'interface-datastore'
+import type { AbortOptions } from 'interface-store'
 
 /**
  * Wraps a given datastore into a keytransform which
@@ -11,6 +12,9 @@ import type { Datastore } from 'interface-datastore'
  * `/hello/world`.
  */
 export class NamespaceDatastore extends KeyTransformDatastore {
+  private readonly iChild: Datastore
+  private readonly iKey: Key
+
   constructor (child: Datastore, prefix: Key) {
     super(child, {
       convert (key) {
@@ -27,6 +31,78 @@ export class NamespaceDatastore extends KeyTransformDatastore {
 
         return new Key(key.toString().slice(prefix.toString().length), false)
       }
+    })
+
+    this.iChild = child
+    this.iKey = prefix
+  }
+
+  query (q: Query, options?: AbortOptions): AsyncIterable<Pair> {
+    const query: Query = {
+      ...q
+    }
+
+    query.filters = (query.filters ?? []).map(filter => {
+      return ({ key, value }) => filter({ key: this.transform.convert(key), value })
+    })
+
+    const { prefix } = q
+    if (prefix != null && prefix !== '/') {
+      delete query.prefix
+      query.filters.push(({ key }) => {
+        return this.transform.invert(key).toString().startsWith(prefix)
+      })
+    }
+
+    if (query.orders != null) {
+      query.orders = query.orders.map(order => {
+        return (a, b) => order(
+          { key: this.transform.invert(a.key), value: a.value },
+          { key: this.transform.invert(b.key), value: b.value }
+        )
+      })
+    }
+
+    query.filters.unshift(({ key }) => this.iKey.isAncestorOf(key))
+
+    return map(this.iChild.query(query, options), ({ key, value }) => {
+      return {
+        key: this.transform.invert(key),
+        value
+      }
+    })
+  }
+
+  queryKeys (q: KeyQuery, options?: AbortOptions): AsyncIterable<Key> {
+    const query = {
+      ...q
+    }
+
+    query.filters = (query.filters ?? []).map(filter => {
+      return (key) => filter(this.transform.convert(key))
+    })
+
+    const { prefix } = q
+    if (prefix != null && prefix !== '/') {
+      delete query.prefix
+      query.filters.push((key) => {
+        return this.transform.invert(key).toString().startsWith(prefix)
+      })
+    }
+
+    if (query.orders != null) {
+      query.orders = query.orders.map(order => {
+        return (a, b) => order(
+          this.transform.invert(a),
+          this.transform.invert(b)
+        )
+      })
+    }
+
+    query.filters.unshift(key => this.iKey.isAncestorOf(key))
+
+    return map(this.iChild.queryKeys(query, options), key => {
+      return this.transform.invert(key)
     })
   }
 }

--- a/packages/datastore-core/test/namespace.spec.ts
+++ b/packages/datastore-core/test/namespace.spec.ts
@@ -13,18 +13,19 @@ describe('NamespaceDatastore', () => {
     'abc',
     ''
   ]
+
+  const keys = [
+    'foo',
+    'foo/bar',
+    'foo/bar/baz',
+    'foo/barb',
+    'foo/bar/bazb',
+    'foo/bar/baz/barb'
+  ].map((s) => new Key(s))
+
   prefixes.forEach((prefix) => it(`basic '${prefix}'`, async () => {
     const mStore = new MemoryDatastore()
     const store = new NamespaceDatastore(mStore, new Key(prefix))
-
-    const keys = [
-      'foo',
-      'foo/bar',
-      'foo/bar/baz',
-      'foo/barb',
-      'foo/bar/bazb',
-      'foo/bar/baz/barb'
-    ].map((s) => new Key(s))
 
     await Promise.all(keys.map(async key => { await store.put(key, uint8ArrayFromString(key.toString())) }))
     const nResults = Promise.all(keys.map(async (key) => store.get(key)))
@@ -44,6 +45,41 @@ describe('NamespaceDatastore', () => {
 
     expect(results[0]).to.eql(results[1])
   }))
+
+  const setupStores = async (keys: Key[]): Promise<NamespaceDatastore[]> => {
+    const prefixes = ['abc', '123', 'sub/prefix']
+    const mStore = new MemoryDatastore()
+
+    return Promise.all(prefixes.map(async prefix => {
+      const store = new NamespaceDatastore(mStore, new Key(prefix))
+
+      await Promise.all(keys.map(async key => { await store.put(key, uint8ArrayFromString(key.toString())) }))
+
+      return store
+    }))
+  }
+
+  it('queries keys under each prefix', async () => {
+    const stores = await setupStores(keys)
+
+    for (const store of stores) {
+      const nRes = await all(store.queryKeys({}))
+
+      expect(nRes).deep.equal(keys)
+    }
+  })
+
+  it('queries values under each prefix', async () => {
+    const stores = await setupStores(keys)
+
+    for (const store of stores) {
+      const nRes = await all(store.query({}))
+      const values = keys.map(key => uint8ArrayFromString(key.toString()))
+
+      expect(nRes.map(p => p.key)).deep.equal(keys)
+      expect(nRes.map(p => p.value)).deep.equal(values)
+    }
+  })
 
   prefixes.forEach((prefix) => {
     describe(`interface-datastore: '${prefix}'`, () => {


### PR DESCRIPTION
This PR stops the error that the namespaced datastore throws when queried, see #236 for reproduction.

Fixes: #236