### PR TITLE
fix: identity blockstore should wrap child

### DIFF
--- a/packages/blockstore-core/package.json
+++ b/packages/blockstore-core/package.json
@@ -110,6 +110,7 @@
   "devDependencies": {
     "aegir": "^42.2.3",
     "interface-blockstore-tests": "^6.0.0",
+    "it-all": "^3.0.4",
     "uint8arrays": "^5.0.2"
   }
 }

--- a/packages/blockstore-core/src/identity.ts
+++ b/packages/blockstore-core/src/identity.ts
@@ -17,7 +17,7 @@ export class IdentityBlockstore extends BaseBlockstore {
   }
 
   put (key: CID, block: Uint8Array): Await<CID> {
-    if (key.code === IDENTITY_CODEC) {
+    if (key.multihash.code === IDENTITY_CODEC) {
       return key
     }
 
@@ -29,7 +29,7 @@ export class IdentityBlockstore extends BaseBlockstore {
   }
 
   get (key: CID): Await<Uint8Array> {
-    if (key.code === IDENTITY_CODEC) {
+    if (key.multihash.code === IDENTITY_CODEC) {
       return key.multihash.digest
     }
 
@@ -41,7 +41,7 @@ export class IdentityBlockstore extends BaseBlockstore {
   }
 
   has (key: CID): Await<boolean> {
-    if (key.code === IDENTITY_CODEC) {
+    if (key.multihash.code === IDENTITY_CODEC) {
       return true
     }
 
@@ -62,9 +62,11 @@ export class IdentityBlockstore extends BaseBlockstore {
     }
   }
 
-  * getAll (options?: AbortOptions): AwaitIterable<Pair> {
+  getAll (options?: AbortOptions): AwaitIterable<Pair> {
     if (this.child != null) {
-      yield * this.child.getAll(options)
+      return this.child.getAll(options)
     }
+
+    return []
   }
 }

--- a/packages/blockstore-core/test/identity.spec.ts
+++ b/packages/blockstore-core/test/identity.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
+import all from 'it-all'
 import drain from 'it-drain'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
@@ -24,18 +25,6 @@ describe('identity', () => {
     const multihash = identity.digest(block)
     const cid = CID.createV1(identity.code, multihash)
 
-    expect(blockstore.has(cid)).to.be.true()
-    expect(blockstore.get(cid)).to.equalBytes(block)
-  })
-
-  it('retrieves CIDs from child', async () => {
-    const block = Uint8Array.from([0, 1, 2, 3, 4])
-    const multihash = await sha256.digest(block)
-    const cid = CID.createV1(raw.code, multihash)
-
-    await child.put(cid, block)
-
-    blockstore = new IdentityBlockstore(child)
     expect(blockstore.has(cid)).to.be.true()
     expect(blockstore.get(cid)).to.equalBytes(block)
   })
@@ -70,5 +59,71 @@ describe('identity', () => {
     await drain(blockstore.deleteMany([cid]))
 
     expect(blockstore.has(cid)).to.be.true()
+  })
+
+  it('puts CIDs to child', async () => {
+    const block = Uint8Array.from([0, 1, 2, 3, 4])
+    const multihash = await sha256.digest(block)
+    const cid = CID.createV1(raw.code, multihash)
+
+    blockstore = new IdentityBlockstore(child)
+
+    await blockstore.put(cid, block)
+    expect(child.has(cid)).to.be.true()
+    expect(child.get(cid)).to.equalBytes(block)
+  })
+
+  it('gets CIDs from child', async () => {
+    const block = Uint8Array.from([0, 1, 2, 3, 4])
+    const multihash = await sha256.digest(block)
+    const cid = CID.createV1(raw.code, multihash)
+
+    await child.put(cid, block)
+
+    blockstore = new IdentityBlockstore(child)
+    expect(blockstore.has(cid)).to.be.true()
+    expect(blockstore.get(cid)).to.equalBytes(block)
+  })
+
+  it('has CIDs from child', async () => {
+    const block = Uint8Array.from([0, 1, 2, 3, 4])
+    const multihash = await sha256.digest(block)
+    const cid = CID.createV1(raw.code, multihash)
+
+    await child.put(cid, block)
+
+    blockstore = new IdentityBlockstore(child)
+    expect(blockstore.has(cid)).to.be.true()
+  })
+
+  it('deletes CIDs from child', async () => {
+    const block = Uint8Array.from([0, 1, 2, 3, 4])
+    const multihash = await sha256.digest(block)
+    const cid = CID.createV1(raw.code, multihash)
+
+    await child.put(cid, block)
+
+    blockstore = new IdentityBlockstore(child)
+    expect(blockstore.has(cid)).to.be.true()
+
+    await blockstore.delete(cid)
+
+    expect(blockstore.has(cid)).to.be.false()
+  })
+
+  it('gets all pairs from child', async () => {
+    const block = Uint8Array.from([0, 1, 2, 3, 4])
+    const multihash = await sha256.digest(block)
+    const cid = CID.createV1(raw.code, multihash)
+
+    await child.put(cid, block)
+
+    blockstore = new IdentityBlockstore(child)
+    expect(blockstore.has(cid)).to.be.true()
+
+    const result = await all(blockstore.getAll())
+
+    expect(result).to.have.lengthOf(1)
+    expect(result[0].cid.toString()).to.equal(cid.toString())
   })
 })


### PR DESCRIPTION
Allow passing a child blockstore to an identity blockstore.