### PR TITLE
fix: run release in each package

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lint": "aegir run lint",
     "dep-check": "aegir run dep-check",
     "release": "run-s build docs:no-publish npm:release docs",
-    "npm:release": "aegir release",
+    "npm:release": "aegir run release",
     "docs": "aegir docs",
     "docs:no-publish": "aegir docs --publish false"
   },


### PR DESCRIPTION
The latest version of aegir ships with semantic-release-monorepo which should be run in each package, not the root.