### PR TITLE
fix(blockstore-fs): allow non sha-256 multihashes

### DIFF
--- a/packages/blockstore-fs/src/sharding.ts
+++ b/packages/blockstore-fs/src/sharding.ts
@@ -45,7 +45,7 @@ export class NextToLast implements ShardingStrategy {
   }
 
   encode (cid: CID): { dir: string, file: string } {
-    const str = this.base.encoder.encode(cid.multihash.bytes)
+    const str = this.base.encoder.encode(cid.bytes)
     const prefix = str.substring(str.length - this.prefixLength)
 
     return {
@@ -97,7 +97,7 @@ export class FlatDirectory implements ShardingStrategy {
   }
 
   encode (cid: CID): { dir: string, file: string } {
-    const str = this.base.encoder.encode(cid.multihash.bytes)
+    const str = this.base.encoder.encode(cid.bytes)
 
     return {
       dir: '',


### PR DESCRIPTION
Multihashes aren't CID's thus decode fails when not using a `sha-256` mutlihash.
It currently works fine with `sha-256` (code 18) multihashes as 18 is the prefix to CIDv0 thus the decode works ok.

The `CID.decode` here https://github.com/ipfs/js-stores/blob/main/packages/blockstore-fs/src/sharding.ts#L64 eventually calls `inspectBytes` https://github.com/multiformats/js-multiformats/blob/master/src/cid.ts#L345 which fails.

Proposed fix is to use `CID.bytes` instead of `CID.multihash.bytes`.

Potentially a breaking change as any current files won't be accessible.