### PR TITLE
chore: deprecate blockstore-level and datastore-fs

### DIFF
--- a/packages/blockstore-level/README.md
+++ b/packages/blockstore-level/README.md
@@ -1,5 +1,9 @@
 # blockstore-level
 
+## ⚠️ Deprecation Warning
+
+**This package is deprecated. Instead, use `blockstore-fs` in node.js, and `blockstore-idb` in browsers.**
+
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
 [![Discuss](https://img.shields.io/discourse/https/discuss.ipfs.tech/posts.svg?style=flat-square)](https://discuss.ipfs.tech)
 [![codecov](https://img.shields.io/codecov/c/github/ipfs/js-stores.svg?style=flat-square)](https://codecov.io/gh/ipfs/js-stores)
@@ -24,9 +28,9 @@ repo and examine the changes made.
 
 -->
 
-A Blockstore implementation that uses a flavour of [Level](https://leveljs.org/) as a backend.
+⚠️ This package is deprecated. Instead, use `blockstore-fs` in node.js, and `blockstore-idb` in browsers.
 
-N.b. this is here largely for the sake of completeness, in node you should probably use FSDatastore, in browsers you should probably use IDBDatastore.
+A Blockstore implementation that uses a flavour of [Level](https://leveljs.org/) as a backend.
 
 ## Example
 

--- a/packages/blockstore-level/src/index.ts
+++ b/packages/blockstore-level/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * @packageDocumentation
  *
- * A Blockstore implementation that uses a flavour of [Level](https://leveljs.org/) as a backend.
+ * ⚠️ This package is deprecated. Instead, use `blockstore-fs` in node.js, and `blockstore-idb` in browsers.
  *
- * N.b. this is here largely for the sake of completeness, in node you should probably use FSDatastore, in browsers you should probably use IDBDatastore.
+ * A Blockstore implementation that uses a flavour of [Level](https://leveljs.org/) as a backend.
  *
  * @example
  *

--- a/packages/datastore-fs/README.md
+++ b/packages/datastore-fs/README.md
@@ -1,5 +1,9 @@
 # datastore-fs
 
+## ⚠️ Deprecation Warning
+
+**This package is deprecated. Instead, use `datastore-level` in node.js, and `datastore-idb` in browsers.**
+
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
 [![Discuss](https://img.shields.io/discourse/https/discuss.ipfs.tech/posts.svg?style=flat-square)](https://discuss.ipfs.tech)
 [![codecov](https://img.shields.io/codecov/c/github/ipfs/js-stores.svg?style=flat-square)](https://codecov.io/gh/ipfs/js-stores)
@@ -23,6 +27,8 @@ To experiment with formatting, please run "npm run docs" from the root of this
 repo and examine the changes made.
 
 -->
+
+⚠️ This package is deprecated. Instead, use `datastore-level` in node.js, and `datastore-idb` in browsers.
 
 A Datastore implementation with a file system backend.
 

--- a/packages/datastore-fs/src/index.ts
+++ b/packages/datastore-fs/src/index.ts
@@ -1,6 +1,8 @@
 /**
  * @packageDocumentation
  *
+ * ⚠️ This package is deprecated. Instead, use `datastore-level` in node.js, and `datastore-idb` in browsers.
+ *
  * A Datastore implementation with a file system backend.
  *
  * @example


### PR DESCRIPTION
As discussed in person `blockstore-level` and `datastore-fs` should be deprecated. 


