### PR TITLE
fix: make IdentityBlockstore.get async generator to fix yield* delega...

### DIFF
--- a/packages/blockstore-core/src/identity.ts
+++ b/packages/blockstore-core/src/identity.ts
@@ -45,7 +45,7 @@ export class IdentityBlockstore extends BaseBlockstore {
     return this.child.put(key, block, options)
   }
 
-  * get (key: CID, options?: AbortOptions): AwaitGenerator<Uint8Array> {
+  async * get (key: CID, options?: AbortOptions): AwaitGenerator<Uint8Array> {
     if (key.multihash.code === IDENTITY_CODEC) {
       if (this.maxDigestLength != null && key.multihash.digest.byteLength > this.maxDigestLength) {
         throw new IdentityHashDigestTooLongError(`Identity digest too long - ${key.multihash.digest.byteLength} > this.maxDigestLength`)
@@ -97,7 +97,7 @@ export class IdentityBlockstore extends BaseBlockstore {
     }
   }
 
-  * getAll (options?: AbortOptions): AwaitGenerator<Pair> {
+  async * getAll (options?: AbortOptions): AwaitGenerator<Pair> {
     if (this.child != null) {
       yield * this.child.getAll(options)
     }

--- a/packages/blockstore-core/src/memory.ts
+++ b/packages/blockstore-core/src/memory.ts
@@ -51,7 +51,7 @@ export class MemoryBlockstore extends BaseBlockstore {
     return key
   }
 
-  * get (key: CID, options?: AbortOptions): AwaitGenerator<Uint8Array> {
+  async * get (key: CID, options?: AbortOptions): AwaitGenerator<Uint8Array> {
     options?.signal?.throwIfAborted()
     const buf = this.data.get(base32.encode(key.multihash.bytes))
 
@@ -72,10 +72,10 @@ export class MemoryBlockstore extends BaseBlockstore {
     this.data.delete(base32.encode(key.multihash.bytes))
   }
 
-  * getAll (options?: AbortOptions): AwaitGenerator<Pair> {
+  async * getAll (options?: AbortOptions): AwaitGenerator<Pair> {
     options?.signal?.throwIfAborted()
 
-    for (const [key, value] of this.data.entries()) {
+    for await (const [key, value] of this.data.entries()) {
       yield {
         cid: CID.createV1(raw.code, Digest.decode(base32.decode(key))),
         bytes: (async function * () {

--- a/packages/blockstore-core/test/identity.spec.ts
+++ b/packages/blockstore-core/test/identity.spec.ts
@@ -141,7 +141,7 @@ describe('identity', () => {
     expect(blockstore.put(CID.createV1(raw.code, identity.digest(ok)), buf)).to.be.ok()
     expect(blockstore.has(CID.createV1(raw.code, identity.digest(ok)))).to.be.ok()
 
-    expect(() => all(blockstore.get(CID.createV1(raw.code, identity.digest(tooLong))))).to.throw()
+    await expect(all(blockstore.get(CID.createV1(raw.code, identity.digest(tooLong))))).to.eventually.be.rejected()
       .with.property('name', 'IdentityHashDigestTooLongError')
 
     expect(() => blockstore.put(CID.createV1(raw.code, identity.digest(tooLong)), buf)).to.throw()
@@ -150,4 +150,24 @@ describe('identity', () => {
     expect(() => blockstore.has(CID.createV1(raw.code, identity.digest(tooLong)))).to.throw()
       .with.property('name', 'IdentityHashDigestTooLongError')
   })
+
+  it('should work with async generator blockstores (fixes yield* delegation bug)', async () => {
+    // This test specifically verifies that IdentityBlockstore.get() works correctly
+    // when delegating to child blockstores that return async generators.
+    // Previously, IdentityBlockstore.get() was a sync generator (* get) which
+    // cannot delegate to async generators using yield*. The fix changes it to
+    // async * get, allowing proper delegation.
+    const block = Uint8Array.from([0, 1, 2, 3, 4]);
+    const multihash = await sha256.digest(block);
+    const cid = CID.createV1(raw.code, multihash);
+
+    blockstore = new IdentityBlockstore(child);
+
+    // Put block in child
+    await child.put(cid, block);
+
+    // Get block through IdentityBlockstore - this should work with async generator delegation
+    const result = await toBuffer(blockstore.get(cid));
+    expect(result).to.equalBytes(block);
+  });
 })


### PR DESCRIPTION
Thanks to @NiKrause for finding the fix

- Change IdentityBlockstore.get from sync generator (* get) to async generator (async * get)
- Fixes TypeError: yield* (intermediate value) is not iterable when delegating to async generator blockstores
- Make MemoryBlockstore.get an async generator to reveal similar problems
- Add test case to verify async generator delegation works correctly
- Fixes issue ipfs#361