### PR TITLE
fix: correct broken API docs URLs in README files

### DIFF
--- a/packages/interface-blockstore/README.md
+++ b/packages/interface-blockstore/README.md
@@ -44,7 +44,7 @@ $ npm i interface-blockstore
 
 # API Docs
 
-- <https://ipfs.github.io/js-stores/modules/interface_blockstore.html>
+- <https://ipfs.github.io/js-stores/modules/interface-blockstore.html>
 
 # License
 

--- a/packages/interface-datastore/README.md
+++ b/packages/interface-datastore/README.md
@@ -134,7 +134,7 @@ Loading this module through a script tag will make its exports available as `Int
 
 # API Docs
 
-- <https://ipfs.github.io/js-stores/modules/interface_datastore.html>
+- <https://ipfs.github.io/js-stores/modules/interface-datastore.html>
 
 # License
 

--- a/packages/interface-store/README.md
+++ b/packages/interface-store/README.md
@@ -34,7 +34,7 @@ $ npm i interface-store
 
 # API Docs
 
-- <https://ipfs.github.io/js-stores/modules/interface_store.html>
+- <https://ipfs.github.io/js-stores/modules/interface-store.html>
 
 # License
 


### PR DESCRIPTION
Fixes #367

The API docs links in three packages used underscores in the module path, but TypeDoc generates paths with hyphens. Updated the URLs in:
- packages/interface-blockstore/README.md
- packages/interface-datastore/README.md
- packages/interface-store/README.md